### PR TITLE
Moved custom dropped XP out of the drops if clause.

### DIFF
--- a/src/main/java/se/crafted/chrisb/ecoCreature/managers/ecoRewardManager.java
+++ b/src/main/java/se/crafted/chrisb/ecoCreature/managers/ecoRewardManager.java
@@ -157,6 +157,9 @@ public class ecoRewardManager implements Cloneable
         }
         else {
             Integer exp = reward.getExpAmount();
+            if (exp != null) {
+                event.setDroppedExp(exp);
+            }
             String weaponName = event.getTamedCreature() != null ? RewardType.fromEntity(event.getTamedCreature()).getName() : Material.getMaterial(event.getKiller().getItemInHand().getTypeId()).name();
             registerReward(event.getKiller(), reward, weaponName);
             try {
@@ -166,9 +169,6 @@ public class ecoRewardManager implements Cloneable
                         event.getDrops().clear();
                     }
                     event.getDrops().addAll(rewardDrops);
-                    if (exp != null) {
-                        event.setDroppedExp(exp);
-                    }
                 }
             }
             catch (IllegalArgumentException e) {


### PR DESCRIPTION
Moved setExperience outside of the drops conditional, so that experience can be changed without overriding any of the default drops.  That is, like money, if the ExpMin, ExpMax, and ExpPercentage are defined for a mob, they will override the default XP drops. This way, we don't have to override all drops in order to change the xp for one or two mobs.
