### PR TITLE
Added entity tracking as an option for anti-camping routines.

### DIFF
--- a/src/main/java/se/crafted/chrisb/ecoCreature/listeners/ecoEntityListener.java
+++ b/src/main/java/se/crafted/chrisb/ecoCreature/listeners/ecoEntityListener.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 
@@ -42,5 +43,14 @@ public class ecoEntityListener implements Listener
         }
 
         Bukkit.getPluginManager().callEvent(new CreatureKilledByPlayerEvent(event));
+    }
+    
+    @EventHandler(priority= EventPriority.MONITOR)
+    public void onCreatureSpawn(CreatureSpawnEvent event)
+    {
+        if (event.isCancelled())
+            return;
+        if(event.getSpawnReason().equals(CreatureSpawnEvent.SpawnReason.SPAWNER))
+            ecoEntityUtil.setSpawnerMob(event.getEntity());
     }
 }

--- a/src/main/java/se/crafted/chrisb/ecoCreature/managers/ecoConfigManager.java
+++ b/src/main/java/se/crafted/chrisb/ecoCreature/managers/ecoConfigManager.java
@@ -112,6 +112,8 @@ public class ecoConfigManager
 
         rewardManager.canCampSpawner = config.getBoolean("System.Hunting.AllowCamping", false);
         rewardManager.shouldClearCampDrops = config.getBoolean("System.Hunting.ClearCampDrops", true);
+        rewardManager.campByDistance = config.getBoolean("System.Hunting.CampingByDistance", true);
+        rewardManager.campByEntity = config.getBoolean("System.Hunting.CampingByEntity", false);
         rewardManager.shouldClearDefaultDrops = config.getBoolean("System.Hunting.ClearDefaultDrops", true);
         rewardManager.shouldOverrideDrops = config.getBoolean("System.Hunting.OverrideDrops", true);
         rewardManager.isFixedDrops = config.getBoolean("System.Hunting.FixedDrops", false);

--- a/src/main/java/se/crafted/chrisb/ecoCreature/managers/ecoRewardManager.java
+++ b/src/main/java/se/crafted/chrisb/ecoCreature/managers/ecoRewardManager.java
@@ -28,6 +28,8 @@ public class ecoRewardManager implements Cloneable
     public Boolean isIntegerCurrency;
 
     public Boolean canCampSpawner;
+    public boolean campByDistance;
+    public boolean campByEntity;
     public boolean shouldClearDefaultDrops;
     public Boolean shouldOverrideDrops;
     public Boolean isFixedDrops;
@@ -136,13 +138,18 @@ public class ecoRewardManager implements Cloneable
             // TODO: message no arena awards?
             return;
         }
-        else if ((ecoEntityUtil.isNearSpawner(event.getKiller()) || ecoEntityUtil.isNearSpawner(event.getKilledCreature())) && !canCampSpawner) {
-            if (shouldClearCampDrops) {
-                event.getDrops().clear();
-                event.setDroppedExp(0);
+        else if (!canCampSpawner && (campByDistance || campByEntity)) {
+            //Reordered the conditional slightly, to make it more efficient, since 
+            //java will stop evaluating when it knows the outcome.
+            if( (campByEntity &&  ecoEntityUtil.isSpawnerMob(event.getKilledCreature())) ||
+                (campByDistance && (ecoEntityUtil.isNearSpawner(event.getKiller()) || ecoEntityUtil.isNearSpawner(event.getKilledCreature()))) ) {
+                    if (shouldClearCampDrops) {
+                        event.getDrops().clear();
+                        event.setDroppedExp(0);
+                    }
+                    ecoCreature.getMessageManager(event.getKiller()).sendMessage(ecoCreature.getMessageManager(event.getKiller()).noCampMessage, event.getKiller());
+                    return;
             }
-            ecoCreature.getMessageManager(event.getKiller()).sendMessage(ecoCreature.getMessageManager(event.getKiller()).noCampMessage, event.getKiller());
-            return;
         }
         else if (!hasPermission(event.getKiller(), "reward." + RewardType.fromEntity(event.getKilledCreature()).getName())) {
             return;

--- a/src/main/java/se/crafted/chrisb/ecoCreature/utils/ecoEntityUtil.java
+++ b/src/main/java/se/crafted/chrisb/ecoCreature/utils/ecoEntityUtil.java
@@ -1,5 +1,6 @@
 package se.crafted.chrisb.ecoCreature.utils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -53,6 +54,8 @@ public class ecoEntityUtil
     private static final long DAWN_START = 22000;
     private static final long SUNRISE_START = 23000;
 
+    private static ArrayList spawnerMobs = new ArrayList();
+    
     public static enum TimePeriod {
         DAY, SUNSET, DUSK, NIGHT, DAWN, SUNRISE, IDENTITY;
 
@@ -87,6 +90,21 @@ public class ecoEntityUtil
             }
         }
         return false;
+    }
+    
+    public static boolean isSpawnerMob(Entity entity)
+    {
+        return spawnerMobs.remove((Integer)entity.getEntityId());
+    }
+    
+    public static void setSpawnerMob(Entity entity)
+    {
+        //Only add to the array if we're tracking by entity. Avoids a memory leak.
+        if(!ecoCreature.getRewardManager(entity).canCampSpawner 
+                && ecoCreature.getRewardManager(entity).campByEntity) {
+            if(!spawnerMobs.contains(entity.getEntityId()))
+                spawnerMobs.add(entity.getEntityId());
+        }
     }
 
     public static CreatureType getCreatureType(Entity entity)

--- a/src/main/resources/default.yml
+++ b/src/main/resources/default.yml
@@ -15,8 +15,17 @@ System:
         # Default: true
         ClearCampDrops: true
         #
-        # How many blocks away from a spawner you need to be to get a reward
-        # Default: 7            
+        # Determine camping by closeness to spawner
+        # Default: true
+        CampingByDistance: true
+        #
+        # Determine camping by remembering entities spawned by mobspawners.
+        # Default: false
+        CampingByEntity: false
+        #
+        # If CampingByDistance is true, then this is how many blocks
+        # away from a spawner you need to be to get a reward
+        # Default: 7             
         CampRadius: 7
         #
         # Do not drop anything except for rewards defined in this file


### PR DESCRIPTION
We were having issues with using distance-to-spawner camping routines, since our players would just construct grinders that moved spawned creatures away from the distance.  Increasing the distance would have adverse effects on players not grinding.  So I implementing an entity tracker as another anti-camp option.  This way, a server manager can use either method (or both) to determine anti-camping.
