### PR TITLE
Multipliers

### DIFF
--- a/src/main/java/se/crafted/chrisb/ecoCreature/managers/ecoRewardManager.java
+++ b/src/main/java/se/crafted/chrisb/ecoCreature/managers/ecoRewardManager.java
@@ -275,14 +275,14 @@ public class ecoRewardManager implements Cloneable
         //Double groupAmount = 0D;
         //Double timeAmount = 0D;
         //Double envAmount = 0D;
-        Double TotalAmount = 0D;
+        Double TotalAmount = amount;
 
         try {
             if (ecoCreature.permission.getPrimaryGroup(player.getWorld().getName(), player.getName()) != null) {
                 String group = ecoCreature.permission.getPrimaryGroup(player.getWorld().getName(), player.getName()).toLowerCase();
                 if (hasPermission(player, "gain.group") && groupMultiplier.containsKey(group)) {
                     //groupAmount = amount * groupMultiplier.get(group) - amount;
-                    TotalAmount = amount * groupMultiplier,get(group);
+                    TotalAmount = TotalAmount * groupMultiplier.get(group);
                 }
             }
         }


### PR DESCRIPTION
The way you set up the multipliers allows for negative numbers being given to players on kills, for example, if you had the End enviroment multiplier at 0.1, and the daytime multiplier at 0.7, and didnt use the group multiplier at all, say the award was 1 credit. ( 1_0.1)-1= -0.9 (1_0.7)-1= -0.3 1+-0.9 +-0.3= -0.2 Multipliers are usually meant to multiply, so unless a multiplier is negative there shouldn't be any possible negative values.
