### PR TITLE
Added Support For Wither Skeletons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>bukkit</artifactId>
-      <version>1.4.4-R0.1-SNAPSHOT</version>
+      <version>1.4.5-R0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>craftbukkit</artifactId>
-      <version>1.4.4-R0.1-SNAPSHOT</version>
+      <version>1.4.5-R0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>net.milkbowl.vault</groupId>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.simiancage.deathtpplus</groupId>
       <artifactId>DeathTpPlus</artifactId>
-      <version>1.95-SNAPSHOT</version>
+      <version>4.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.sk89q</groupId>

--- a/src/main/java/se/crafted/chrisb/ecoCreature/settings/RewardSourceFactory.java
+++ b/src/main/java/se/crafted/chrisb/ecoCreature/settings/RewardSourceFactory.java
@@ -103,6 +103,7 @@ public final class RewardSourceFactory
             case ANGRY_WOLF:
             case PLAYER:
             case POWERED_CREEPER:
+            case WITHER_SKELETON:
                 source = new EntityRewardSource(config);
                 break;
             default:

--- a/src/main/java/se/crafted/chrisb/ecoCreature/settings/types/CustomEntityRewardType.java
+++ b/src/main/java/se/crafted/chrisb/ecoCreature/settings/types/CustomEntityRewardType.java
@@ -27,6 +27,8 @@ import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Skeleton;
+import org.bukkit.entity.Skeleton.SkeletonType;
 import org.bukkit.entity.Wolf;
 
 import se.crafted.chrisb.ecoCreature.commons.LoggerUtil;
@@ -36,6 +38,7 @@ public enum CustomEntityRewardType
     ANGRY_WOLF("AngryWolf"),
     PLAYER("Player"),
     POWERED_CREEPER("PoweredCreeper"),
+    WITHER_SKELETON("WitherSkeleton"),
     INVALID("__Invalid__");
 
     private static final Map<String, CustomEntityRewardType> NAME_MAP = new HashMap<String, CustomEntityRewardType>();
@@ -76,6 +79,9 @@ public enum CustomEntityRewardType
         }
         else if (entity instanceof Wolf && ((Wolf) entity).isAngry()) {
             entityType = CustomEntityRewardType.ANGRY_WOLF;
+        }
+        else if (entity instanceof Skeleton && ((Skeleton) entity).getSkeletonType() == SkeletonType.WITHER) {
+            entityType = CustomEntityRewardType.WITHER_SKELETON;
         }
         else if (entity instanceof LivingEntity) {
             entityType = CustomEntityRewardType.fromName(entity.getType().getName());

--- a/src/main/resources/default.yml
+++ b/src/main/resources/default.yml
@@ -561,6 +561,10 @@ RewardTable:
     Coin_Percent: 100.0
     Drops:
     - 'nether star:1-1:100'
+  WitherSkeleton:
+    Coin_Minimum: 1.00
+    Coin_Maximum: 3.00
+    Coin_Percent: 50.0
   Wolf:
     Coin_Minimum: 1.00
     Coin_Maximum: 2.00


### PR DESCRIPTION
This commit lets ecoCreature distinguish between normal and Wither skeletons, meaning that Wither skeletons now drop the loot that they should (coal, bones and possibly a wither skull head). I didn't include the actual drops in the config so that the default are just used - I'm not sure why you've specified the drops for the others.

I also had to change the DeathTpPlus dependency version to get it to compile, as well as the Bukkit and CraftBukkit versions as 1.4.5 added the skeleton API.
